### PR TITLE
Reuse optuna study

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ python tuning.py
 
 Ensure you have configured the `model_config.yaml` file beforehand.
 
+Rerunning `tuning.py` will reuse the existing Optuna study stored at
+`studies/tuning_crnn.sqlite3`. Delete this database file if you want to start a
+fresh tuning session.
+
 ---
 
 ## Configuration

--- a/model/tuning.py
+++ b/model/tuning.py
@@ -81,13 +81,16 @@ if __name__ == "__main__":
     optuna_dir = PROJECT_ROOT / "studies"
     optuna_dir.mkdir(exist_ok=True)
 
-    db_path = optuna_dir / "tunign_crnn.sqlite3"
+    db_path = optuna_dir / "tuning_crnn.sqlite3"
     storage_name = f"sqlite:///{db_path}"
 
     # Multi-objective optimization with Optuna
-    study = optuna.create_study(directions=["minimize", "minimize", "minimize"],
-                                study_name = optuna_config['study_name'], 
-                                storage = storage_name)
+    study = optuna.create_study(
+        directions=["minimize", "minimize", "minimize"],
+        study_name=optuna_config['study_name'],
+        storage=storage_name,
+        load_if_exists=True
+    )
     
     study.optimize(objective, n_trials=15)
 


### PR DESCRIPTION
## Summary
- ensure tuning reuses existing study database by default
- document that removing `studies/tuning_crnn.sqlite3` resets tuning

## Testing
- `python -m py_compile model/tuning.py`

------
https://chatgpt.com/codex/tasks/task_e_68556498c040832babda128b7657d3f8