### PR TITLE
Fix imports for module execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ python train.py
 To fine-tune the model, run:
 
 ```bash
-python tuning.py
+python -m model.tuning
 ```
 
 Ensure you have configured the `model_config.yaml` file beforehand.

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,0 +1,5 @@
+"""Utility package for model training and tuning."""
+
+from .models import create_model, ModelConfig
+
+__all__ = ["create_model", "ModelConfig"]

--- a/model/train.py
+++ b/model/train.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
 import matplotlib.pyplot as plt
-from models import create_model, ModelConfig
+from .models import create_model, ModelConfig
 import yaml
 import tensorflow as tf
 from tensorflow import keras

--- a/model/tuning.py
+++ b/model/tuning.py
@@ -1,6 +1,6 @@
 import optuna
 import numpy as np
-from train import train_model
+from .train import train_model
 import os
 import yaml
 from pathlib import Path


### PR DESCRIPTION
## Summary
- add `model/__init__.py`
- use relative imports inside `model` package
- document tuning command using `python -m model.tuning`

## Testing
- `python -m py_compile model/__init__.py model/train.py model/tuning.py model/models.py`

------
https://chatgpt.com/codex/tasks/task_e_685566ec08f0832bb24b134cc88ff84e